### PR TITLE
Prevent using same request without changing captcha

### DIFF
--- a/src/Mews/Captcha/Captcha.php
+++ b/src/Mews/Captcha/Captcha.php
@@ -182,11 +182,12 @@ class Captcha {
      */
     public static function check($value)
     {
-
-		$captchaHash = Session::get('captchaHash');
+        $captchaHash = Session::get('captchaHash');
+        
+        //Clear captcha, so same request can't be re-used. 
+        Session::forget('captchaHash');
 
         return $value != null && $captchaHash != null && Hash::check(static::$config['sensitive'] === true ? $value : Str::lower($value), $captchaHash);
-
     }
 
     /**


### PR DESCRIPTION
If someone enter proper captcha on one page, and have another page which just check was captcha valid, he can make unlimited number of requests with simply refreshing the page, without need to enter new captcha. This happens because you re-create hash only when image is created, but if someone don't show captcha, and check on the same page, then Hash will be created on first page, and on second it will be always valid.