### PR TITLE
Reset fonts array index

### DIFF
--- a/src/Captcha.php
+++ b/src/Captcha.php
@@ -199,6 +199,7 @@ class Captcha
     {
         $this->backgrounds = $this->files->files(__DIR__ . '/../assets/backgrounds');
         $this->fonts = $this->files->files(__DIR__ . '/../assets/fonts');
+        $this->fonts = array_values($this->fonts); //reset fonts array index
 
         $this->configure($config);
 


### PR DESCRIPTION
On linux,  

```$this->files->files(__DIR__ . '/../assets/fonts');``` 

produces

```php 
[
     0 => 'xx.font',
     1 => 'xx.font',
     2 => 'xx.font',
     4 => 'xx.font',
     5 => 'xx.font',
     6 => 'xx.font'
]
```
missing index ```3```

I believe it's the folder inside the fonts folder and files() method did not treat it properly cause this.