### PR TITLE
Need include php_fileinfo.dll and php_mbstring.dll 

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,10 @@ composer require mews/captcha
 
 Update your packages with ```composer update``` or install with ```composer install```.
 
-In Windows, you'll need to include the GD2 DLL `php_gd2.dll` as an extension in php.ini.
+In Windows, you'll need to include the GD2 DLL `php_gd2.dll` in php.ini. And you also need include `php_fileinfo.dll` and `php_mbstring.dll` to fit the requirements of `mews/captcha`'s dependencies.
+
+
+
 
 ## Usage
 


### PR DESCRIPTION
I am new to php and composer.
composer complain requires `ext-fileinfo` and `ext-mbstring` while installing mews/captcha. Looks like the dependencies of mews/captcha need those.
I figure it out , but it would be confused to rookies(the names are  different in php.ini). So I think add the information would be better.