### PR TITLE
Implement Math Capcha by adding math attribute to Captcha class

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A simple [Laravel 5](http://www.laravel.com/) service provider for including the
 for Laravel 4 [Captcha for Laravel Laravel 4](https://github.com/mewebstudio/captcha/tree/master-l4)
 
 ## Preview
-![Preview](http://i.imgur.com/HYtr744.png)
+![Preview](https://image.ibb.co/kZxMLm/image.png)
 
 ## Installation
 
@@ -91,6 +91,7 @@ return [
         'width'     => 120,
         'height'    => 36,
         'quality'   => 90,
+        'math'      => true, //Enable Math Captcha
     ],
     // ...
 ];

--- a/config/captcha.php
+++ b/config/captcha.php
@@ -5,10 +5,11 @@ return [
     'characters' => '2346789abcdefghjmnpqrtuxyzABCDEFGHJMNPQRTUXYZ',
 
     'default'   => [
-        'length'    => 5,
+        'length'    => 9,
         'width'     => 120,
         'height'    => 36,
         'quality'   => 90,
+        'math'      => true,
     ],
 
     'flat'   => [

--- a/src/Captcha.php
+++ b/src/Captcha.php
@@ -160,6 +160,11 @@ class Captcha
     protected $sensitive = false;
 
     /**
+     * @var bool
+     */
+    protected $math = false;
+
+    /**
      * Constructor
      *
      * @param Filesystem $files
@@ -291,14 +296,24 @@ class Captcha
         $characters = str_split($this->characters);
 
         $bag = '';
-        for($i = 0; $i < $this->length; $i++)
-        {
-            $bag .= $characters[rand(0, count($characters) - 1)];
+        $key = '';
+
+        if ($this->math) {
+            $x = random_int(10, 30);
+            $y = random_int(1, 9);
+            $bag = "$x + $y = ";
+            $key = $x + $y;
+            $key .= '';
+        } else {
+            for ($i = 0; $i < $this->length; $i++) {
+                $bag .= $characters[rand(0, count($characters) - 1)];
+            }
+            $key = $this->sensitive ? $bag : $this->str->lower($bag);
         }
 
         $this->session->put('captcha', [
             'sensitive' => $this->sensitive,
-            'key'       => $this->hasher->make($this->sensitive ? $bag : $this->str->lower($bag))
+            'key'       => $this->hasher->make($key)
         ]);
 
         return $bag;


### PR DESCRIPTION
I've add new attribute called `math (default false)` and it can be configured via `config/captcha.php` file.
By turning this attribute to true, captcha display simple sum equation like `17 + 5 =` and the captcha key will be th `22`.
Sorry for my non-native English.