### PR TITLE
Adding control to the generated img tag attributes

### DIFF
--- a/src/Captcha.php
+++ b/src/Captcha.php
@@ -454,7 +454,7 @@ class Captcha
             }
             $attrs_str .= $key.'="'.$value.'" ';
         }
-        return '<img src="' . $this->src($config) . '" trim($attrs_str)>';
+        return '<img src="' . $this->src($config) . '" '. trim($attrs_str).'>';
     }
 
 }

--- a/src/Captcha.php
+++ b/src/Captcha.php
@@ -444,7 +444,7 @@ class Captcha
      * and the value is the attribute value
      * @return string
      */
-    public function img($config = null, $attrs = ['alt' => 'captcha'])
+    public function img($config = null, $attrs = [])
     {
         $attrs_str = '';
         foreach($attrs as $attr => $value){

--- a/src/Captcha.php
+++ b/src/Captcha.php
@@ -440,11 +440,21 @@ class Captcha
      * Generate captcha image html tag
      *
      * @param null $config
+     * @param array $attrs HTML attributes supplied to the image tag where key is the attribute
+     * and the value is the attribute value
      * @return string
      */
-    public function img($config = null)
+    public function img($config = null, $attrs = ['alt' => __('captcha')])
     {
-        return '<img src="' . $this->src($config) . '" alt="captcha">';
+        $attrs_str = '';
+        foreach($attrs as $attr => $value){
+            if ($key == 'src'){
+                //Neglect src attribute
+                continue;
+            }
+            $attrs_str .= $key.'="'.$value.'" ';
+        }
+        return '<img src="' . $this->src($config) . '" trim($attrs_str)>';
     }
 
 }

--- a/src/Captcha.php
+++ b/src/Captcha.php
@@ -444,7 +444,7 @@ class Captcha
      * and the value is the attribute value
      * @return string
      */
-    public function img($config = null, $attrs = ['alt' => __('captcha')])
+    public function img($config = null, $attrs = ['alt' => 'captcha'])
     {
         $attrs_str = '';
         foreach($attrs as $attr => $value){

--- a/src/Captcha.php
+++ b/src/Captcha.php
@@ -448,11 +448,11 @@ class Captcha
     {
         $attrs_str = '';
         foreach($attrs as $attr => $value){
-            if ($key == 'src'){
+            if ($attr == 'src'){
                 //Neglect src attribute
                 continue;
             }
-            $attrs_str .= $key.'="'.$value.'" ';
+            $attrs_str .= $attr.'="'.$value.'" ';
         }
         return '<img src="' . $this->src($config) . '" '. trim($attrs_str).'>';
     }


### PR DESCRIPTION
An optional parameter named `$attrs` is added to the `img()` method. It is an associative array with keys for attributes names and its value for the attribute value.
This option gives more control on the generated image tag by specifying attributes such as `id, class, style, etc`