### PR TITLE
Added src parameter which isn't optional anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,11 +138,11 @@ Captcha::create();
 
 # Return URL
 ```php
-captcha_src();
+captcha_src('default');
 ```
 or
 ```
-Captcha::src();
+Captcha::src('default');
 ```
 
 # Return HTML


### PR DESCRIPTION
Don't know if only 'default' is okay in the README.
My captchas stopped working, I have to call Captcha::src(null) now instead of Captcha::src().