### PR TITLE
Fix error on OctoberCms

### DIFF
--- a/src/Captcha.php
+++ b/src/Captcha.php
@@ -15,7 +15,7 @@ namespace Mews\Captcha;
  */
 
 use Exception;
-use Illuminate\Config\Repository;
+use Illuminate\Contracts\Config\Repository;
 use Illuminate\Hashing\BcryptHasher as Hasher;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Http\File;

--- a/src/CaptchaServiceProvider.php
+++ b/src/CaptchaServiceProvider.php
@@ -73,7 +73,7 @@ class CaptchaServiceProvider extends ServiceProvider
         $this->app->bind('captcha', function ($app) {
             return new Captcha(
                 $app['Illuminate\Filesystem\Filesystem'],
-                $app['Illuminate\Config\Repository'],
+                $app['Illuminate\Contracts\Config\Repository'],
                 $app['Intervention\Image\ImageManager'],
                 $app['Illuminate\Session\Store'],
                 $app['Illuminate\Hashing\BcryptHasher'],


### PR DESCRIPTION
Argument 2 passed to Mews\Captcha\Captcha::__construct() must be an instance of Illuminate\Config\Repository, instance of October\Rain\Config\Repository given, called in /var/www/beeline/vendor/mews/captcha/src/CaptchaServiceProvider.php on line 70
