### PR TITLE
Fix validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,9 @@ You get key and img from this url
 and verify the captcha using this method:
 ```php
     //key is the one that you got from json response
-    $rules = ['captcha' => 'required|captcha_api:'. request('key')];
+    // fix validator
+    // $rules = ['captcha' => 'required|captcha_api:'. request('key')];
+    $rules = ['captcha' => 'required|captcha_api:'. request('key') . ',default'];
     $validator = validator()->make(request()->all(), $rules);
     if ($validator->fails()) {
         return response()->json([

--- a/src/Captcha.php
+++ b/src/Captcha.php
@@ -345,7 +345,8 @@ class Captcha
         
         $this->session->put('captcha', [
             'sensitive' => $this->sensitive,
-            'key' => $hash
+            'key' => $hash,
+            'encrypt' => $this->encrypt
         ]);
 
         return [
@@ -467,12 +468,13 @@ class Captcha
 
         $key = $this->session->get('captcha.key');
         $sensitive = $this->session->get('captcha.sensitive');
+        $encrypt = $this->session->get('captcha.encrypt');
 
         if (!$sensitive) {
             $value = $this->str->lower($value);
         }
 
-        if($this->encrypt) $key = Crypt::decrypt($key);
+        if($encrypt) $key = Crypt::decrypt($key);
         $check = $this->hasher->check($value, $key);
         // if verify pass,remove session
         if ($check) {
@@ -487,13 +489,16 @@ class Captcha
      *
      * @param string $value
      * @param string $key
+     * @param string $config
      * @return bool
      */
-    public function check_api($value, $key): bool
+    public function check_api($value, $key, $config = 'default'): bool
     {
         if (!Cache::pull('captcha_record_' . $key)) {
             return false;
         }
+
+        $this->configure($config);
 
         if($this->encrypt) $key = Crypt::decrypt($key);
         return $this->hasher->check($value, $key);

--- a/src/CaptchaServiceProvider.php
+++ b/src/CaptchaServiceProvider.php
@@ -52,7 +52,7 @@ class CaptchaServiceProvider extends ServiceProvider
 
         // Validator extensions
         $validator->extend('captcha_api', function ($attribute, $value, $parameters) {
-            return captcha_api_check($value, $parameters[0]);
+            return captcha_api_check($value, $parameters[0], $parameters[1] ?? 'default');
         });
     }
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -52,10 +52,11 @@ if (!function_exists('captcha_api_check')) {
     /**
      * @param string $value
      * @param string $key
+     * @param string $config
      * @return bool
      */
-    function captcha_api_check(string $value, string $key): bool
+    function captcha_api_check(string $value, string $key, string $config = 'default'): bool
     {
-        return app('captcha')->check_api($value, $key);
+        return app('captcha')->check_api($value, $key, $config);
     }
 }


### PR DESCRIPTION
The validator use `check` or `check_api` method, which forget loading config when init.

https://github.com/mewebstudio/captcha/blob/39569c990901820f3228853dd9471812b3227958/src/Captcha.php#L462
https://github.com/mewebstudio/captcha/blob/39569c990901820f3228853dd9471812b3227958/src/Captcha.php#L492

---

**For example:**

`encrypt` is `false` as default in `captcha.php`.
https://github.com/mewebstudio/captcha/blob/39569c990901820f3228853dd9471812b3227958/config/captcha.php#L12

But when you `check` or `check_api`，the value will always be `true`.
https://github.com/mewebstudio/captcha/blob/39569c990901820f3228853dd9471812b3227958/src/Captcha.php#L190

So there will be an exception:
```
Illuminate\Contracts\Encryption\DecryptException
The payload is invalid.
```
