### PR TITLE
Use dirname function to get the parent directory

### DIFF
--- a/src/Captcha.php
+++ b/src/Captcha.php
@@ -216,7 +216,7 @@ class Captcha
         $this->hasher = $hasher;
         $this->str = $str;
         $this->characters = config('captcha.characters', ['1', '2', '3', '4', '6', '7', '8', '9']);
-        $this->fontsDirectory = config('captcha.fontsDirectory', __DIR__ . '/../assets/fonts');
+        $this->fontsDirectory = config('captcha.fontsDirectory',  dirname(__DIR__) . '/assets/fonts');
     }
 
     /**


### PR DESCRIPTION
The verification code cannot be displayed in my place. After investigation, it is found that the font path is incorrect, with a `'../'` in the middle, which is not automatically converted to the upper-level directory. Modifying `__DIR__.'/../Assets/fonts'` to `dirname(__DIR__).'/Assets/fonts'` solved my problem. But I don't know why `'../'` cannot be converted correctly.