### PR TITLE
Add feature to disable by config or environment variable (for develop and local purpose)

### DIFF
--- a/config/captcha.php
+++ b/config/captcha.php
@@ -1,6 +1,7 @@
 <?php
 
 return [
+    'disable' => env('CAPTCHA_DISABLE', !str_contains(env('APP_ENV', 'local'), 'prod')),
     'characters' => ['2', '3', '4', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'j', 'm', 'n', 'p', 'q', 'r', 't', 'u', 'x', 'y', 'z', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'J', 'M', 'N', 'P', 'Q', 'R', 'T', 'U', 'X', 'Y', 'Z'],
     'default' => [
         'length' => 9,

--- a/src/CaptchaServiceProvider.php
+++ b/src/CaptchaServiceProvider.php
@@ -47,12 +47,12 @@ class CaptchaServiceProvider extends ServiceProvider
 
         // Validator extensions
         $validator->extend('captcha', function ($attribute, $value, $parameters) {
-            return captcha_check($value);
+            return config('captcha.disable') || ($value && captcha_check($value));
         });
 
         // Validator extensions
         $validator->extend('captcha_api', function ($attribute, $value, $parameters) {
-            return captcha_api_check($value, $parameters[0], $parameters[1] ?? 'default');
+            return config('captcha.disable') || ($value && captcha_api_check($value, $parameters[0], $parameters[1] ?? 'default'));
         });
     }
 


### PR DESCRIPTION
If `disable` parameter in config set to `true` captcha validation rule always return `true`.
Since it's value maybe null if disable was false also check value of captcha to be `not null`