### PR TITLE
Separating captcha expiration from Laravel session lifetime

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ return [
         'height'    => 36,
         'quality'   => 90,
         'math'      => true,  //Enable Math Captcha
-        'expire'    => 60,    //Stateless/API captcha expiration
+        'expire'    => 60,    //Captcha expiration
     ],
     // ...
 ];

--- a/src/Captcha.php
+++ b/src/Captcha.php
@@ -298,9 +298,7 @@ class Captcha
             $this->image->blur($this->blur);
         }
 
-        if ($api) {
-            Cache::put($this->get_cache_key($generator['key']), $generator['value'], $this->expire);
-        }
+        Cache::put($this->get_cache_key($generator['key']), $generator['value'], $this->expire);
 
         return $api ? [
             'sensitive' => $generator['sensitive'],
@@ -477,6 +475,11 @@ class Captcha
         $key = $this->session->get('captcha.key');
         $sensitive = $this->session->get('captcha.sensitive');
         $encrypt = $this->session->get('captcha.encrypt');
+
+        if (!Cache::pull($this->get_cache_key($key))) {
+            $this->session->remove('captcha');
+            return false;
+        }
 
         if (!$sensitive) {
             $value = $this->str->lower($value);


### PR DESCRIPTION
By default captcha expiration is based on the lifetime of the Laravel session.
So for example if your session lifetime is set to 120 minutes, the bots have about 2 hours more time to guess the captcha.
With this configuration you can manage captcha expiration with configuration file.

`config/captcha.php`

```php
return [
    'default'   => [
        'length'    => 5,
        'width'     => 120,
        'height'    => 36,
        'quality'   => 90,
        'expire'    => 60,    //60 second captcha expiration
    ],
    // ...
];
```