### PR TITLE
Fixed duplicate declaration in Captcha.php

### DIFF
--- a/src/Captcha.php
+++ b/src/Captcha.php
@@ -29,7 +29,6 @@ use Illuminate\Session\Store as Session;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Crypt;
-use Illuminate\Http\Response;
 
 
 /**


### PR DESCRIPTION
`use Illuminate\Http\Response;` is declared twice which causes errors.