### PR TITLE
[Bugfix] API Response: Resolved EncodedImage Error

### DIFF
--- a/src/Captcha.php
+++ b/src/Captcha.php
@@ -308,7 +308,7 @@ class Captcha
         return $api ? [
             'sensitive' => $generator['sensitive'],
             'key' => $generator['key'],
-            'img' => $this->image->encode()->encoded
+            'img' => $this->image->encode()->toDataUri()
         ] : new Response($this->image->encode(), 200, [
             'Content-Type' => 'image/jpeg',
             'Content-Disposition' => 'inline; filename="image.jpg"',


### PR DESCRIPTION
- **Fix:**
  - Resolved the error `Undefined property: Intervention\Image\EncodedImage::$encoded` by replacing `$this->image->encode()->encoded` with `$this->image->encode()->toDataUri()` in the codebase, ensuring proper handling of encoded images in API responses.