### PR TITLE
Provider documentation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ for Laravel 5.1+
         Mews\Captcha\CaptchaServiceProvider::class,
     ]
 ```
+For Laravel 11+ you can add the provider to 'bootstrap\providers.php'.
+```php
+return [
+    // ...
+    Mews\Captcha\CaptchaServiceProvider::class
+];
+```
 
 Find the `aliases` key in `config/app.php`.
 
@@ -98,7 +105,7 @@ for Laravel 5.1+
     ]
 ```
 
-For Laravel 11 : you do not need to add the alias, it will be added automatically.
+For Laravel 11+ : you do not need to add the alias, it will be added automatically.
 
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ for Laravel 5.1+
         Mews\Captcha\CaptchaServiceProvider::class,
     ]
 ```
-For Laravel 11+ you can add the provider to 'bootstrap\providers.php'.
+For Laravel 11+ you can add the provider to `bootstrap\providers.php`.
 ```php
 return [
     // ...


### PR DESCRIPTION
Inserted additional instruction for how to add a provider for Laravel 11+ which uses bootstrap/providers.php.  I ran into this issue when trying to use it with Laravel 12 and just thought this would help folks.