### PR TITLE
Explicit float to int typecast - fixes #311

### DIFF
--- a/src/Captcha.php
+++ b/src/Captcha.php
@@ -397,7 +397,7 @@ class Captcha
         foreach ($text as $key => $char) {
             $marginLeft = $this->textLeftPadding + ($key * ($this->image->width() - $this->textLeftPadding) / $this->length);
 
-            $this->image->text($char, $marginLeft, $marginTop, function ($font) {
+            $this->image->text($char, (int) $marginLeft, (int) $marginTop, function ($font) {
                 /* @var Font $font */
                 $font->file($this->font());
                 $font->size($this->fontSize());


### PR DESCRIPTION
This PR fixes the warning: 

> Implicit conversion from float 7.2 to int loses precision in /vendor/intervention/image/src/Image.php on line 617

Reason for this warning is that the `text` function expects int values for the `$x` and `$y` points.

Since PHP 8.1 this warning notice is emmited, as implicit float -> int conversion is being deprecated.

This PR simply casts the floats to integers explicitly.

Not sure if it would be better to round, floor, or ceil the values?
