### PR TITLE
Update intervention/image version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "illuminate/support": "~5|^6|^7|^8|^9|^10|^11|^12|^13.0",
         "illuminate/hashing": "~5|^6|^7|^8|^9|^10|^11|^12|^13.0",
         "illuminate/session": "~5|^6|^7|^8|^9|^10|^11|^12|^13.0",
-        "intervention/image": "^3.7|^4.0"
+        "intervention/image": "^3.7"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5|^9.5.10|^10.5|^11",


### PR DESCRIPTION
If version >= 4 is installed.
Error Call to undefined method Intervention\Image\ImageManager::create because the dependencies for version 4 and later use ImageManager::createImage(